### PR TITLE
Add DKG module with defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = []
+members = ["dkg"]
 resolver = "3"
 
 [workspace.package]

--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "frost-dkg-channel"
+authors.workspace = true
+version.workspace = true
+license.workspace = true
+description.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+edition.workspace = true
+
+[features]
+default = ["p256", "ed25519", "quic-https"]
+p256 = ["dep:frost-p256"]
+ed25519 = ["dep:frost-ed25519"]
+quic-https = ["dep:quinn"]
+
+[dependencies]
+frost-p256 = { version = "=2.2.0", default-features = false, features = [
+    "cheater-detection",
+], optional = true }
+frost-ed25519 = { version = "=2.2.0", default-features = false, features = [
+    "cheater-detection",
+], optional = true }
+
+quinn = { version = "=0.11.9", default-features = false, features = [
+    "runtime-smol",
+    "rustls",
+], optional = true }
+rand = "0.8"

--- a/dkg/src/ed25519/dkg.rs
+++ b/dkg/src/ed25519/dkg.rs
@@ -1,0 +1,210 @@
+use std::collections::BTreeMap;
+
+use frost_ed25519::{
+    self as frost,
+    keys::{
+        dkg::round1::Package as Ed25519Round1Package,
+        dkg::round1::SecretPackage as Ed25519Round1SecretPackage,
+        dkg::round2::Package as Ed25519Round2Package,
+        dkg::round2::SecretPackage as Ed25519Round2SecretPackage,
+    },
+    Identifier as Ed25519Identifier,
+};
+
+use crate::{DkgState, FrostEd25519Keypair};
+
+type Round1PackagesStore = BTreeMap<Ed25519Identifier, Ed25519Round1Package>;
+type Round2PackagesStore = BTreeMap<Ed25519Identifier, Ed25519Round2Package>;
+
+#[derive(Debug)]
+pub struct FrostEd25519Dkg {
+    state: DkgState,
+    // Identifier of current party
+    party_id: &'static str,
+    other_parties: Vec<&'static str>,
+    round1_secret: Option<Ed25519Round1SecretPackage>,
+    round2_secret: Option<Ed25519Round2SecretPackage>,
+    round1_package: Option<Ed25519Round1Package>,
+    received_round1_packages: Round1PackagesStore,
+    computed_round2_packages: Round2PackagesStore,
+    received_round2_packages: Round2PackagesStore,
+    max_signers: u16,
+    min_signers: u16,
+}
+
+impl FrostEd25519Dkg {
+    /// Default to `5` maximum signers and `3` minimum signers
+    pub fn new(party_id: &'static str) -> Self {
+        let max_signers = 2u16;
+        let min_signers = 1u16;
+
+        Self {
+            state: DkgState::Initial,
+            party_id,
+            other_parties: Vec::with_capacity(max_signers as usize),
+            round1_secret: Option::default(),
+            round2_secret: Option::default(),
+            round1_package: Option::default(),
+            received_round1_packages: BTreeMap::default(),
+            computed_round2_packages: BTreeMap::default(),
+            received_round2_packages: BTreeMap::default(),
+            min_signers,
+            max_signers,
+        }
+    }
+
+    pub fn set_minimum_signers(mut self, minimum_signers: u16) -> Self {
+        self.min_signers = minimum_signers;
+
+        self
+    }
+
+    pub fn set_maximum_signers(mut self, maximum_signers: u16) -> Self {
+        self.max_signers = maximum_signers;
+
+        self
+    }
+
+    pub fn add_party(&mut self, party_identifier: &'static str) -> &mut Self {
+        if self.state != DkgState::Initial {
+            panic!("Max signers already reached. ")
+        }
+
+        self.other_parties.push(party_identifier);
+        self.other_parties.dedup();
+
+        if self.other_parties.len() == self.max_signers as usize {
+            self.state = DkgState::Round1
+        }
+
+        self
+    }
+
+    pub fn add_parties(&mut self, party_identifier: &[&'static str]) -> &mut Self {
+        party_identifier.iter().for_each(|party| {
+            self.add_party(party);
+        });
+
+        self
+    }
+
+    /// Each participant generates their own identifier
+    pub fn part1(&mut self) -> &mut Self {
+        let rng = rand::rngs::OsRng;
+
+        let identifier = Self::get_identifier(self.party_id);
+
+        let (round1_secret, round1_package) =
+            frost::keys::dkg::part1(identifier, self.max_signers, self.min_signers, rng).unwrap();
+
+        self.round1_secret.replace(round1_secret);
+        self.round1_package.replace(round1_package);
+
+        self
+    }
+
+    pub fn part2(&mut self) -> &mut Self {
+        let round1_secret = self.round1_secret.take().unwrap();
+
+        let (round2_secret_package, mut round2_packages) =
+            frost::keys::dkg::part2(round1_secret, &self.received_round1_packages).unwrap();
+
+        self.round2_secret.replace(round2_secret_package);
+        self.computed_round2_packages.append(&mut round2_packages);
+
+        self
+    }
+
+    pub fn part3(&mut self) -> FrostEd25519Keypair {
+        if self.state != DkgState::Round3 {
+            panic!("Expected state to be RoundThree at this stage")
+        }
+        let round2_secret = self.round2_secret.take().unwrap();
+
+        let (signing_key, verifying_key) = frost::keys::dkg::part3(
+            &round2_secret,
+            &self.received_round1_packages,
+            &self.received_round2_packages,
+        )
+        .unwrap();
+
+        FrostEd25519Keypair::new(self.party_id(), signing_key, verifying_key)
+    }
+
+    pub fn get_identifier(party_identifier: &'static str) -> Ed25519Identifier {
+        Ed25519Identifier::derive(party_identifier.as_bytes()).unwrap()
+    }
+
+    pub fn add_received_round1_package(
+        &mut self,
+        party_identifier: &'static str,
+        package: Ed25519Round1Package,
+    ) -> &mut Self {
+        if !self.party_is_authorized(party_identifier) {
+            panic!("party is not authorized for participation")
+        }
+
+        if self.state != DkgState::Round1 {
+            panic!("Expected state to be RoundOne at this stage")
+        }
+
+        self.received_round1_packages
+            .insert(Self::get_identifier(party_identifier), package);
+
+        if self.received_round1_packages.len() == (self.max_signers - 1) as usize {
+            self.state = DkgState::Round2
+        }
+
+        self
+    }
+
+    pub fn party_is_authorized(&self, party_id: &'static str) -> bool {
+        self.other_parties.contains(&party_id)
+    }
+
+    pub fn add_received_round2_package(
+        &mut self,
+        party_that_transmitted: &'static str,
+        package: Ed25519Round2Package,
+    ) -> &mut Self {
+        if !self.party_is_authorized(party_that_transmitted) {
+            panic!("party is not authorized for participation")
+        }
+
+        if self.state != DkgState::Round2 {
+            panic!("Expected state to be RoundTwo at this stage")
+        }
+        self.received_round2_packages
+            .insert(Self::get_identifier(party_that_transmitted), package);
+
+        if self.received_round2_packages.len() == (self.max_signers - 1) as usize {
+            self.state = DkgState::Round3
+        }
+
+        self
+    }
+
+    pub fn transmit_round2_package(
+        &self,
+        party_identifier: &'static str,
+    ) -> Option<&Ed25519Round2Package> {
+        self.computed_round2_packages
+            .get(&Self::get_identifier(party_identifier))
+    }
+
+    pub fn party_id(&self) -> &'static str {
+        self.party_id
+    }
+
+    pub fn identifier(&self) -> Ed25519Identifier {
+        Self::get_identifier(self.party_id)
+    }
+
+    pub fn round1_package(&self) -> Option<&Ed25519Round1Package> {
+        self.round1_package.as_ref()
+    }
+
+    pub fn round2_package(&self) -> &Round2PackagesStore {
+        &self.computed_round2_packages
+    }
+}

--- a/dkg/src/ed25519/keypair.rs
+++ b/dkg/src/ed25519/keypair.rs
@@ -1,0 +1,37 @@
+use frost_ed25519::{
+    keys::{KeyPackage as Ed25519KeyPackage, PublicKeyPackage as Ed25519PublicKeyPackage},
+    Identifier as Ed25519Identifier,
+};
+
+#[derive(Debug)]
+pub struct FrostEd25519Keypair {
+    party_id: &'static str,
+    signing_key: Ed25519KeyPackage,
+    verifying_key: Ed25519PublicKeyPackage,
+}
+
+impl FrostEd25519Keypair {
+    pub(crate) fn new(
+        party_id: &'static str,
+        signing_key: Ed25519KeyPackage,
+        verifying_key: Ed25519PublicKeyPackage,
+    ) -> Self {
+        Self {
+            party_id,
+            signing_key,
+            verifying_key,
+        }
+    }
+
+    pub fn verifying_key(&self) -> &Ed25519PublicKeyPackage {
+        &self.verifying_key
+    }
+
+    pub fn party_id(&self) -> &'static str {
+        self.party_id
+    }
+
+    pub fn identifier(&self) -> Ed25519Identifier {
+        Ed25519Identifier::derive(self.party_id.as_bytes()).unwrap()
+    }
+}

--- a/dkg/src/ed25519/mod.rs
+++ b/dkg/src/ed25519/mod.rs
@@ -1,0 +1,5 @@
+mod dkg;
+pub use dkg::*;
+
+mod keypair;
+pub use keypair::*;

--- a/dkg/src/main.rs
+++ b/dkg/src/main.rs
@@ -1,0 +1,71 @@
+mod ed25519;
+pub use ed25519::*;
+
+mod state;
+pub use state::*;
+
+fn main() {
+    let party1: &str = "party1@server.party";
+    let party2: &str = "party2@server.party";
+
+    println!(
+        "Party1 Identifier: {:?}",
+        FrostEd25519Dkg::get_identifier(party1)
+    );
+    println!(
+        "Party2 Identifier: {:?}",
+        FrostEd25519Dkg::get_identifier(party2)
+    );
+
+    let mut party1_dkg = FrostEd25519Dkg::new(party1)
+        .set_maximum_signers(2)
+        .set_minimum_signers(2);
+    let mut party2_dkg = FrostEd25519Dkg::new(party2)
+        .set_maximum_signers(2)
+        .set_minimum_signers(2);
+    let parties = &[party1, party2];
+    party1_dkg.add_parties(parties);
+    party2_dkg.add_parties(parties);
+
+    // Round1 /////////////////
+    party1_dkg.part1();
+    party2_dkg.part1();
+
+    // --- Party 1 Round1 Channel Send
+    party1_dkg.add_received_round1_package(
+        party2_dkg.party_id(),
+        party2_dkg.round1_package().unwrap().clone(),
+    );
+    // --- Party 2 Round1 Channel Send
+    party2_dkg.add_received_round1_package(
+        party1_dkg.party_id(),
+        party1_dkg.round1_package().unwrap().clone(),
+    );
+
+    // // Round2 /////////////////
+    party1_dkg.part2();
+    party2_dkg.part2();
+    // --- Party 1 Round2 Channel Send
+    let party1_round2_pacakge = party2_dkg
+        .transmit_round2_package(party1_dkg.party_id())
+        .unwrap()
+        .clone();
+
+    // --- Party 2 Round2 Channel Send
+    let party2_round2_pacakge = party1_dkg
+        .transmit_round2_package(party2_dkg.party_id())
+        .unwrap()
+        .clone();
+
+    party1_dkg.add_received_round2_package(party2, party1_round2_pacakge);
+    party2_dkg.add_received_round2_package(party1, party2_round2_pacakge);
+
+    // Round3 /////////////////
+    let party1_keypair = party1_dkg.part3();
+    let party2_keypair = party2_dkg.part3();
+
+    assert_eq!(
+        party1_keypair.verifying_key(),
+        party2_keypair.verifying_key()
+    );
+}

--- a/dkg/src/state.rs
+++ b/dkg/src/state.rs
@@ -1,0 +1,7 @@
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy)]
+pub enum DkgState {
+    Initial,
+    Round1,
+    Round2,
+    Round3,
+}


### PR DESCRIPTION
- This initializes the dkg module and adds the default structure for DKG and round1 with simulation for other parties

- Move other parties secrets outside `FrostEd25519Dkg`. This ensures that secrets for other parties are stored outside of current party.

- A `DkgState` enum is introduced to ensure state transition to Round2 and Round3

- Add part2 of the DKG simulation

- Add part3 of the DKG simulation

  - Verify parties are authorized
  - Consider state transitions
  - Ability to simulate transmit package to participant