### PR TITLE
Implement part1 of FROST dkg

### DIFF
--- a/dkg/Cargo.toml
+++ b/dkg/Cargo.toml
@@ -18,9 +18,11 @@ quic-https = ["dep:quinn"]
 [dependencies]
 frost-p256 = { version = "=2.2.0", default-features = false, features = [
     "cheater-detection",
+    "serialization",
 ], optional = true }
 frost-ed25519 = { version = "=2.2.0", default-features = false, features = [
     "cheater-detection",
+    "serialization",
 ], optional = true }
 
 quinn = { version = "=0.11.9", default-features = false, features = [
@@ -34,9 +36,10 @@ frost-core = { version = "2.2.0", default-features = false, features = [
 ] }
 thiserror = { version = "2.0.17", default-features = false }
 zeroize = { version = "1.8.2", default-features = false }
-rand_chacha = { version = "0.9.0", features = ["os_rng"] }
+rand_chacha = { version = "0.9" }
 async-dup = "1.2.4"
 async-lock = "3.4.1"
 async-io = "2.6.0"
 smol = "2.0.2"
 wincode = { version = "0.1.2", features = ["derive"] }
+rand = "0.8"

--- a/dkg/src/ed25519/storage.rs
+++ b/dkg/src/ed25519/storage.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::collections::{BTreeMap, HashMap};
 
 use async_dup::Arc;
@@ -18,92 +19,221 @@ use frost_ed25519::{
     Error, Identifier as Ed25519Identifier,
 };
 use wincode::{SchemaRead, SchemaWrite};
+use zeroize::Zeroize;
 
-use crate::{DkgState, FrostDkgError, FrostDkgResult, FrostDkgStorage, FROST_ED25519_MEM_STORAGE};
+use crate::{
+    FrostDkgEd25519Storage, FrostDkgError, FrostDkgResult, FrostDkgState, FrostDkgStorage,
+};
 
-#[derive(Debug, PartialEq, SchemaRead, SchemaWrite, Default)]
+pub type Round1PackageBytes = Vec<u8>;
+pub type Ed25519IdentifierBytes = Vec<u8>;
+
+#[derive(Zeroize, SchemaRead, SchemaWrite, Default)]
+pub struct Round1SecretBytes(Vec<u8>);
+
+impl fmt::Debug for Round1SecretBytes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Round1SecretBytes<Redacted>")
+    }
+}
+
+#[derive(Debug, SchemaRead, SchemaWrite, Default)]
 pub struct FrostDkgMemStorage {
     identifier: Vec<u8>,
     context_string: &'static str,
     maximum_signers: u16,
     minimum_signers: u16,
-    dkg_state: DkgState,
+    dkg_state: FrostDkgState,
+    part1_secret: Round1SecretBytes,
+    part1_package: Round1PackageBytes,
+    received_part1_packages: BTreeMap<Ed25519IdentifierBytes, Round1PackageBytes>,
 }
 
 impl FrostDkgMemStorage {
     pub fn init() -> Self {
         Self::default()
     }
-
-    pub async fn get_storage() -> FrostDkgResult<Arc<RwLock<Self>>> {
-        FROST_ED25519_MEM_STORAGE
-            .get()
-            .cloned()
-            .ok_or(FrostDkgError::GlobalStorageNotInitialized)
-    }
 }
 
-impl<C: Ciphersuite> FrostDkgStorage<C> for Arc<RwLock<FrostDkgMemStorage>> {
-    async fn set_context_string(
-        &self,
-        context_string: &'static str,
-    ) -> Result<(), impl core::error::Error> {
+impl FrostDkgEd25519Storage for Arc<RwLock<FrostDkgMemStorage>> {}
+
+impl<C: Ciphersuite, E: core::error::Error + std::convert::From<FrostDkgError>>
+    FrostDkgStorage<C, E> for Arc<RwLock<FrostDkgMemStorage>>
+{
+    async fn set_context_string(&self, context_string: &'static str) -> Result<(), E> {
         self.write().await.context_string = context_string;
 
-        Ok::<_, FrostDkgError>(())
+        Ok(())
     }
 
-    async fn get_context_string(&self) -> Result<&'static str, impl core::error::Error> {
-        Ok::<_, FrostDkgError>(self.read().await.context_string)
+    async fn get_context_string(&self) -> Result<&'static str, E> {
+        Ok(self.read().await.context_string)
     }
 
-    async fn set_state(&self, dkg_state: DkgState) -> Result<(), impl core::error::Error> {
+    async fn set_state(&self, dkg_state: FrostDkgState) -> Result<(), E> {
         self.write().await.dkg_state = dkg_state;
 
-        Ok::<(), FrostDkgError>(())
+        Ok(())
     }
 
-    async fn get_state(&self) -> Result<DkgState, impl core::error::Error> {
-        Ok::<_, FrostDkgError>(self.read().await.dkg_state)
+    async fn get_state(&self) -> Result<FrostDkgState, E> {
+        Ok(self.read().await.dkg_state)
     }
 
-    async fn set_identifier(
-        &self,
-        identifier: frost_core::Identifier<C>,
-    ) -> Result<(), impl core::error::Error> {
+    async fn set_identifier(&self, identifier: frost_core::Identifier<C>) -> Result<(), E> {
         self.write().await.identifier = identifier.serialize();
 
-        Ok::<_, FrostDkgError>(())
+        Ok(())
     }
 
-    async fn get_identifier(&self) -> Result<frost_core::Identifier<C>, impl core::error::Error> {
-        frost_core::Identifier::<C>::deserialize(&self.0.read().await.identifier)
-            .map_err(|error| FrostDkgError::Ed25519Sha512IdentifierDeserialize(error.to_string()))
+    async fn get_identifier(&self) -> Result<frost_core::Identifier<C>, E> {
+        Ok(
+            frost_core::Identifier::<C>::deserialize(&self.0.read().await.identifier).map_err(
+                |error| FrostDkgError::Ed25519Sha512IdentifierDeserialize(error.to_string()),
+            )?,
+        )
     }
 
-    async fn set_maximum_signers(
-        &self,
-        maximum_signers: u16,
-    ) -> Result<(), impl core::error::Error> {
+    async fn set_maximum_signers(&self, maximum_signers: u16) -> Result<(), E> {
         self.write().await.maximum_signers = maximum_signers;
 
-        Ok::<_, FrostDkgError>(())
+        Ok(())
     }
 
-    async fn get_maximum_signers(&self) -> Result<u16, impl core::error::Error> {
-        Ok::<_, FrostDkgError>(self.read().await.maximum_signers)
+    async fn get_maximum_signers(&self) -> Result<u16, E> {
+        Ok(self.read().await.maximum_signers)
     }
 
-    async fn set_minimum_signers(
-        &self,
-        minimum_signers: u16,
-    ) -> Result<(), impl core::error::Error> {
+    async fn set_minimum_signers(&self, minimum_signers: u16) -> Result<(), E> {
         self.write().await.minimum_signers = minimum_signers;
 
-        Ok::<_, FrostDkgError>(())
+        Ok(())
     }
 
-    async fn get_minimum_signers(&self) -> Result<u16, impl core::error::Error> {
-        Ok::<_, FrostDkgError>(self.read().await.minimum_signers)
+    async fn get_minimum_signers(&self) -> Result<u16, E> {
+        Ok(self.read().await.minimum_signers)
+    }
+
+    async fn set_part1_package(
+        &self,
+        mut secret: frost_core::keys::dkg::round1::SecretPackage<C>,
+        package: frost_core::keys::dkg::round1::Package<C>,
+    ) -> Result<(), E> {
+        let secret_bytes = secret
+            .serialize()
+            .map_err(|error| FrostDkgError::Ed25519Sha512Round1SecretPackage(error.to_string()))?;
+        let package_bytes = package
+            .serialize()
+            .map_err(|error| FrostDkgError::Ed25519Sha512Round1Package(error.to_string()))?;
+
+        self.write().await.part1_secret = Round1SecretBytes(secret_bytes);
+        self.write().await.part1_package = package_bytes;
+
+        secret.zeroize();
+
+        Ok(())
+    }
+
+    /// This zeroizes the secret so its only accessible once
+    async fn get_part1_secret_package(
+        &self,
+    ) -> Result<frost_core::keys::dkg::round1::SecretPackage<C>, E> {
+        let secret = frost_core::keys::dkg::round1::SecretPackage::<C>::deserialize(
+            &self.read().await.part1_secret.0,
+        )
+        .map_err(|error| FrostDkgError::Ed25519Sha512Part1SecretDeserialize(error.to_string()))?;
+
+        self.write().await.part1_secret.zeroize();
+
+        Ok(secret)
+    }
+
+    async fn get_part1_public_package(
+        &self,
+    ) -> Result<frost_core::keys::dkg::round1::Package<C>, E> {
+        Ok(frost_core::keys::dkg::round1::Package::<C>::deserialize(
+            &self.read().await.part1_package,
+        )
+        .map_err(|error| {
+            FrostDkgError::Ed25519Sha512Part1PublicPackageDeserialize(error.to_string())
+        })?)
+    }
+
+    async fn add_part1_received_package(
+        &self,
+        identifier: frost_core::Identifier<C>,
+        package: frost_core::keys::dkg::round1::Package<C>,
+    ) -> Result<(), E> {
+        let identifier_bytes = identifier.serialize();
+        let package_bytes = package.serialize().map_err(|error| {
+            FrostDkgError::Ed25519SerializeReceivedPart1Package(error.to_string())
+        })?;
+
+        self.write()
+            .await
+            .received_part1_packages
+            .insert(identifier_bytes, package_bytes);
+
+        Ok(())
+    }
+
+    async fn get_part1_received_package(
+        &self,
+        identifier: frost_core::Identifier<C>,
+    ) -> Result<Option<frost_core::keys::dkg::round1::Package<C>>, E> {
+        let identifier_bytes = identifier.serialize();
+
+        Ok(self
+            .read()
+            .await
+            .received_part1_packages
+            .get(&identifier_bytes)
+            .map(|value| {
+                frost_core::keys::dkg::round1::Package::deserialize(value).map_err(|error| {
+                    FrostDkgError::Ed25519DeserializeReceivedPart1Package(error.to_string())
+                })
+            })
+            .transpose()?)
+    }
+
+    async fn has_part1_received_package(
+        &self,
+        identifier: frost_core::Identifier<C>,
+    ) -> Result<bool, E> {
+        let identifier_bytes = identifier.serialize();
+
+        Ok(self
+            .read()
+            .await
+            .received_part1_packages
+            .contains_key(&identifier_bytes))
+    }
+
+    async fn get_all_part1_received_packages(
+        &self,
+    ) -> Result<BTreeMap<frost_core::Identifier<C>, frost_core::keys::dkg::round1::Package<C>>, E>
+    {
+        let mut packages = BTreeMap::<
+            frost_core::Identifier<C>,
+            frost_core::keys::dkg::round1::Package<C>,
+        >::default();
+        self.read()
+            .await
+            .received_part1_packages
+            .iter()
+            .try_for_each(|(key, value)| {
+                let identifier = frost_core::Identifier::deserialize(key).map_err(|error| {
+                    FrostDkgError::Ed25519Sha512IdentifierDeserializeAll(error.to_string())
+                })?;
+                let package = frost_core::keys::dkg::round1::Package::deserialize(value).map_err(
+                    |error| FrostDkgError::Ed25519Part1DeserializeAll(error.to_string()),
+                )?;
+
+                packages.insert(identifier, package);
+
+                Ok(())
+            })?;
+
+        Ok(packages)
     }
 }

--- a/dkg/src/errors.rs
+++ b/dkg/src/errors.rs
@@ -12,6 +12,34 @@ pub enum FrostDkgError {
     IdentifierAlreadyExists,
     #[error("There must be at least two signers for perform distributed key generation")]
     ThereMustBeAtLeast2Signers,
+    #[error("Unable to serialize an Ed25519 secret package. Error: `{0}`.")]
+    Ed25519Sha512Round1SecretPackage(String),
+    #[error("Unable to serialize an Ed25519 public package. Error: `{0}`.")]
+    Ed25519Sha512Round1Package(String),
     #[error("Unable to deserialize an Ed25519Sha512 Identifier. Error: `{0}`.")]
     Ed25519Sha512IdentifierDeserialize(String),
+    #[error("Unable to deserialize an Ed25519Sha512 Part1 secret. Error: `{0}`.")]
+    Ed25519Sha512Part1SecretDeserialize(String),
+    #[error("Unable to deserialize an Ed25519Sha512 Part1 public package. Error: `{0}`.")]
+    Ed25519Sha512Part1PublicPackageDeserialize(String),
+    #[error("Attempted to transition FROST DKG state yet the state is already finalized")]
+    DkgStateAlreadyFinalized,
+    #[error("Invalid FROST DKG state. Error: `{0}`.")]
+    InvalidDkgState(&'static str),
+    #[error("Unable to perform key generation for part 1. Error: `{0}`")]
+    Part1KeyGenerationError(String),
+    #[error("Unable to serialize the received part1 package. Error: `{0}`.")]
+    Ed25519SerializeReceivedPart1Package(String),
+    #[error(
+        "Unable to deserialize the received part1 package fetched from storage. Error: `{0}`."
+    )]
+    Ed25519DeserializeReceivedPart1Package(String),
+    #[error(
+        "Unable to deserialize the identifier when fetching all part1 packages. Error: `{0}`."
+    )]
+    Ed25519Sha512IdentifierDeserializeAll(String),
+    #[error(
+        "Unable to deserialize the part1 package when fetching all part1 packages. Error: `{0}`."
+    )]
+    Ed25519Part1DeserializeAll(String),
 }

--- a/dkg/src/main.rs
+++ b/dkg/src/main.rs
@@ -1,5 +1,3 @@
-use std::sync::OnceLock;
-
 mod ed25519;
 use async_dup::Arc;
 use async_lock::RwLock;
@@ -17,80 +15,233 @@ pub use traits::*;
 mod csprng;
 pub use csprng::*;
 
-static FROST_ED25519_MEM_STORAGE: OnceLock<Arc<RwLock<FrostDkgMemStorage>>> = OnceLock::new();
-
 fn main() {
     smol::block_on(async {
-        FROST_ED25519_MEM_STORAGE
-            .set(Arc::new(RwLock::new(FrostDkgMemStorage::init())))
-            .expect("Mem Storage should be initialized at this stage");
+        let party1 = "alice@example";
 
-        let ed25519_dkg = FrostEd25519Dkg::new();
+        let party2 = "bob@example";
 
-        let ed25519_identifier = ed25519_dkg.generate_identifier().unwrap();
-        ed25519_dkg
+        let ed25519_dkg_party1 =
+            FrostEd25519Dkg::new(Arc::new(RwLock::new(FrostDkgMemStorage::init())));
+
+        {
+            //Init party 1
+            let ed25519_identifier = ed25519_dkg_party1.generate_identifier(party1).unwrap();
+            ed25519_dkg_party1
+                .storage()
+                .await
+                .unwrap()
+                .set_identifier(ed25519_identifier)
+                .await
+                .unwrap();
+
+            ed25519_dkg_party1
+                .storage()
+                .await
+                .unwrap()
+                .set_maximum_signers(2)
+                .await
+                .unwrap();
+
+            ed25519_dkg_party1
+                .storage()
+                .await
+                .unwrap()
+                .set_minimum_signers(2)
+                .await
+                .unwrap();
+
+            ed25519_dkg_party1.part1().await.unwrap();
+        }
+
+        let ed25519_dkg_party2 =
+            FrostEd25519Dkg::new(Arc::new(RwLock::new(FrostDkgMemStorage::init())));
+
+        {
+            //Init party 2
+            let ed25519_identifier = ed25519_dkg_party1.generate_identifier(party2).unwrap();
+            ed25519_dkg_party2
+                .storage()
+                .await
+                .unwrap()
+                .set_identifier(ed25519_identifier)
+                .await
+                .unwrap();
+
+            ed25519_dkg_party2
+                .storage()
+                .await
+                .unwrap()
+                .set_maximum_signers(2)
+                .await
+                .unwrap();
+
+            ed25519_dkg_party2
+                .storage()
+                .await
+                .unwrap()
+                .set_minimum_signers(2)
+                .await
+                .unwrap();
+
+            ed25519_dkg_party2.part1().await.unwrap();
+        }
+
+        let party1_identifier = ed25519_dkg_party1
             .storage()
             .await
             .unwrap()
-            .set_identifier(ed25519_identifier)
+            .get_identifier()
             .await
             .unwrap();
-        assert_eq!(
-            ed25519_dkg
-                .storage()
-                .await
-                .unwrap()
-                .get_identifier()
-                .await
-                .unwrap(),
-            ed25519_identifier
-        );
-
-        assert_eq!(
-            ed25519_dkg
-                .storage()
-                .await
-                .unwrap()
-                .get_state()
-                .await
-                .unwrap(),
-            DkgState::Initial
-        );
-
-        ed25519_dkg
+        let party1_part1_package = ed25519_dkg_party1
             .storage()
             .await
             .unwrap()
-            .set_maximum_signers(2)
+            .get_part1_public_package()
             .await
             .unwrap();
-        assert_eq!(
-            ed25519_dkg
-                .storage()
-                .await
-                .unwrap()
-                .get_maximum_signers()
-                .await
-                .unwrap(),
-            2u16
-        );
 
-        ed25519_dkg
+        let party2_identifier = ed25519_dkg_party2
             .storage()
             .await
             .unwrap()
-            .set_minimum_signers(2)
+            .get_identifier()
             .await
             .unwrap();
-        assert_eq!(
-            ed25519_dkg
-                .storage()
+        let party2_part1_package = ed25519_dkg_party2
+            .storage()
+            .await
+            .unwrap()
+            .get_part1_public_package()
+            .await
+            .unwrap();
+
+        {
+            // Part1
+            ed25519_dkg_party1
+                .receive_part1(party2_identifier, party2_part1_package)
                 .await
-                .unwrap()
-                .get_minimum_signers()
+                .unwrap();
+            ed25519_dkg_party2
+                .receive_part1(party1_identifier, party1_part1_package)
                 .await
-                .unwrap(),
-            2u16
-        );
+                .unwrap();
+        }
     })
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_initialization() {
+        smol::block_on(async {
+            let ed25519_dkg =
+                FrostEd25519Dkg::new(Arc::new(RwLock::new(FrostDkgMemStorage::init())));
+
+            let ed25519_identifier = ed25519_dkg.generate_identifier_random().unwrap();
+            ed25519_dkg
+                .storage()
+                .await
+                .unwrap()
+                .set_identifier(ed25519_identifier)
+                .await
+                .unwrap();
+            assert_eq!(
+                ed25519_dkg
+                    .storage()
+                    .await
+                    .unwrap()
+                    .get_identifier()
+                    .await
+                    .unwrap(),
+                ed25519_identifier
+            );
+
+            assert_eq!(
+                ed25519_dkg
+                    .storage()
+                    .await
+                    .unwrap()
+                    .get_state()
+                    .await
+                    .unwrap(),
+                FrostDkgState::Initial
+            );
+
+            ed25519_dkg
+                .storage()
+                .await
+                .unwrap()
+                .set_maximum_signers(2)
+                .await
+                .unwrap();
+            assert_eq!(
+                ed25519_dkg
+                    .storage()
+                    .await
+                    .unwrap()
+                    .get_maximum_signers()
+                    .await
+                    .unwrap(),
+                2u16
+            );
+
+            ed25519_dkg
+                .storage()
+                .await
+                .unwrap()
+                .set_minimum_signers(2)
+                .await
+                .unwrap();
+            assert_eq!(
+                ed25519_dkg
+                    .storage()
+                    .await
+                    .unwrap()
+                    .get_minimum_signers()
+                    .await
+                    .unwrap(),
+                2u16
+            );
+
+            ed25519_dkg.part1().await.unwrap();
+            assert_eq!(
+                ed25519_dkg
+                    .storage()
+                    .await
+                    .unwrap()
+                    .get_state()
+                    .await
+                    .unwrap(),
+                FrostDkgState::Part1
+            );
+
+            assert!(ed25519_dkg
+                .storage()
+                .await
+                .unwrap()
+                .get_part1_secret_package()
+                .await
+                .is_ok());
+
+            assert!(ed25519_dkg
+                .storage()
+                .await
+                .unwrap()
+                .get_part1_secret_package()
+                .await
+                .is_err());
+
+            assert!(ed25519_dkg
+                .storage()
+                .await
+                .unwrap()
+                .get_part1_public_package()
+                .await
+                .is_ok());
+        })
+    }
 }

--- a/dkg/src/state.rs
+++ b/dkg/src/state.rs
@@ -3,10 +3,10 @@ use wincode::{SchemaRead, SchemaWrite};
 #[derive(
     Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Default, SchemaRead, SchemaWrite,
 )]
-pub enum DkgState {
+pub enum FrostDkgState {
     #[default]
     Initial,
-    Round1,
-    Round2,
+    Part1,
+    Part2,
     Finalized,
 }

--- a/dkg/src/traits.rs
+++ b/dkg/src/traits.rs
@@ -1,8 +1,9 @@
 use std::{collections::BTreeMap, future::Future};
 
 use frost_core::{Ciphersuite, Identifier};
+use frost_ed25519::Ed25519Sha512;
 
-use crate::DkgState;
+use crate::{FrostDkgError, FrostDkgState};
 
 pub trait FrostDkg {
     type DkgGenericError: core::error::Error;
@@ -10,63 +11,109 @@ pub trait FrostDkg {
 
     fn storage(
         &self,
-    ) -> impl Future<Output = Result<impl FrostDkgStorage<Self::DkgCipherSuite>, Self::DkgGenericError>>;
+    ) -> impl Future<
+        Output = Result<
+            impl FrostDkgStorage<Self::DkgCipherSuite, Self::DkgGenericError>,
+            Self::DkgGenericError,
+        >,
+    >;
 
     fn generate_identifier(
         &self,
+        identifier: impl AsRef<[u8]>,
     ) -> Result<frost_core::Identifier<Self::DkgCipherSuite>, Self::DkgGenericError>;
 
-    // fn set_part1_packages(
-    //     &self,
-    //     secret: frost_core::keys::dkg::round1::SecretPackage<Self::DkgCipherSuite>,
-    //     package: frost_core::keys::dkg::round1::Package<Self::DkgCipherSuite>,
-    // ) -> impl Future<Output = Result<(), Self::DkgGenericError>>;
+    fn generate_identifier_random(
+        &self,
+    ) -> Result<frost_core::Identifier<Self::DkgCipherSuite>, Self::DkgGenericError>;
 
-    // /// Sets packages for other parties received via a trusted communication channel
-    // fn set_part1_received_package(
-    //     &self,
-    //     identifier: Identifier<Self::DkgCipherSuite>,
-    //     package: frost_core::keys::dkg::round1::Package<Self::DkgCipherSuite>,
-    // ) -> impl Future<Output = Result<(), Self::DkgGenericError>>;
+    fn frost_dkg_state_transition(
+        &self,
+    ) -> impl Future<Output = Result<FrostDkgState, Self::DkgGenericError>>;
+
+    fn part1(&self) -> impl Future<Output = Result<(), Self::DkgGenericError>>;
+
+    fn receive_part1(
+        &self,
+        identifier: frost_core::Identifier<Self::DkgCipherSuite>,
+        package: frost_core::keys::dkg::round1::Package<Self::DkgCipherSuite>,
+    ) -> impl Future<Output = Result<(), Self::DkgGenericError>>;
+
+    fn send_part1(
+        &self,
+    ) -> impl Future<
+        Output = Result<
+            (
+                frost_core::Identifier<Self::DkgCipherSuite>,
+                frost_core::keys::dkg::round1::Package<Self::DkgCipherSuite>,
+            ),
+            Self::DkgGenericError,
+        >,
+    >;
 }
 
-pub trait FrostDkgStorage<C: Ciphersuite> {
-    fn set_context_string(
-        &self,
-        context_str: &'static str,
-    ) -> impl Future<Output = Result<(), impl core::error::Error>>;
+pub trait FrostDkgEd25519Storage: FrostDkgStorage<Ed25519Sha512, FrostDkgError> {}
 
-    fn get_context_string(
-        &self,
-    ) -> impl Future<Output = Result<&'static str, impl core::error::Error>>;
+pub trait FrostDkgStorage<C: Ciphersuite, E: core::error::Error> {
+    fn set_context_string(&self, context_str: &'static str) -> impl Future<Output = Result<(), E>>;
 
-    fn set_state(
-        &self,
-        state: DkgState,
-    ) -> impl Future<Output = Result<(), impl core::error::Error>>;
+    fn get_context_string(&self) -> impl Future<Output = Result<&'static str, E>>;
 
-    fn get_state(&self) -> impl Future<Output = Result<DkgState, impl core::error::Error>>;
+    fn set_state(&self, state: FrostDkgState) -> impl Future<Output = Result<(), E>>;
+
+    fn get_state(&self) -> impl Future<Output = Result<FrostDkgState, E>>;
 
     fn set_identifier(
         &self,
         identifier: frost_core::Identifier<C>,
-    ) -> impl Future<Output = Result<(), impl core::error::Error>>;
+    ) -> impl Future<Output = Result<(), E>>;
 
-    fn get_identifier(
+    fn get_identifier(&self) -> impl Future<Output = Result<frost_core::Identifier<C>, E>>;
+
+    fn set_maximum_signers(&self, maximum_signers: u16) -> impl Future<Output = Result<(), E>>;
+
+    fn get_maximum_signers(&self) -> impl Future<Output = Result<u16, E>>;
+
+    fn set_minimum_signers(&self, minimum_signers: u16) -> impl Future<Output = Result<(), E>>;
+
+    fn get_minimum_signers(&self) -> impl Future<Output = Result<u16, E>>;
+
+    fn set_part1_package(
         &self,
-    ) -> impl Future<Output = Result<frost_core::Identifier<C>, impl core::error::Error>>;
+        secret: frost_core::keys::dkg::round1::SecretPackage<C>,
+        package: frost_core::keys::dkg::round1::Package<C>,
+    ) -> impl Future<Output = Result<(), E>>;
 
-    fn set_maximum_signers(
+    fn get_part1_secret_package(
         &self,
-        maximum_signers: u16,
-    ) -> impl Future<Output = Result<(), impl core::error::Error>>;
+    ) -> impl Future<Output = Result<frost_core::keys::dkg::round1::SecretPackage<C>, E>>;
 
-    fn get_maximum_signers(&self) -> impl Future<Output = Result<u16, impl core::error::Error>>;
-
-    fn set_minimum_signers(
+    fn get_part1_public_package(
         &self,
-        minimum_signers: u16,
-    ) -> impl Future<Output = Result<(), impl core::error::Error>>;
+    ) -> impl Future<Output = Result<frost_core::keys::dkg::round1::Package<C>, E>>;
 
-    fn get_minimum_signers(&self) -> impl Future<Output = Result<u16, impl core::error::Error>>;
+    fn add_part1_received_package(
+        &self,
+        identifier: frost_core::Identifier<C>,
+        package: frost_core::keys::dkg::round1::Package<C>,
+    ) -> impl Future<Output = Result<(), E>>;
+
+    fn has_part1_received_package(
+        &self,
+        identifier: frost_core::Identifier<C>,
+    ) -> impl Future<Output = Result<bool, E>>;
+
+    fn get_part1_received_package(
+        &self,
+        identifier: frost_core::Identifier<C>,
+    ) -> impl Future<Output = Result<Option<frost_core::keys::dkg::round1::Package<C>>, E>>;
+
+    fn get_all_part1_received_packages(
+        &self,
+    ) -> impl Future<
+        Output = Result<
+            BTreeMap<frost_core::Identifier<C>, frost_core::keys::dkg::round1::Package<C>>,
+            E,
+        >,
+    >;
 }


### PR DESCRIPTION
- This adds the first part of the DKG with storage support.
- Storage is now generic for FROST-Ed25519
- On part1 for current user, the state is transitioned to Part1
- `Round1SecretBytes` type is now a `pub struct Round1SecretBytes(Vec<u8>)` which allows zeroizing of the bytes on take
- `FrostDkgEd25519Storage` trait is introduced to allow `FrostDkgEd25519Storage` struct to take a trait that is `FrostDkgStorage` compatible
- Now `FrostDkgStorage` no longer returns ` impl core::error::Error` for methods instead it takes the error of `FrostDkg`
- Adds tests for creating a DKG, state transition for part1 and storage of part1 packages
- Add storage features for receiving and sending round1 packages