### PR TITLE
Fix redirect bugs

### DIFF
--- a/krill-common/src/auth_token.rs
+++ b/krill-common/src/auth_token.rs
@@ -149,9 +149,10 @@ impl AuthTokenDetails {
     pub fn auth_token_as_cookie_raw(
         &self,
         cookie_auth_token: [u8; Self::AUTH_TOKEN_LEN],
+        same_site: &str,
     ) -> String {
         format!(
-            "{}={}; Path=/; HttpOnly;{} SameSite=Strict; Max-Age={}",
+            "{}={}; Path=/; HttpOnly;{} SameSite={same_site}; Max-Age={}",
             Self::COOKIE_AUTH_TOKEN_IDENTIFIER,
             Self::store_key_bytes_to_hex(cookie_auth_token),
             if cfg!(not(debug_assertions)) {

--- a/krill-common/src/mail_verifier.rs
+++ b/krill-common/src/mail_verifier.rs
@@ -45,7 +45,7 @@ impl From<([u8; AuthTokenDetails::AUTH_TOKEN_LEN], AuthTokenDetails)> for Verify
             timestamp: auth_token_details.timestamp_bytes(),
             expiry,
             retry: auth_token_details.retry(),
-            cookie: auth_token_details.auth_token_as_cookie_raw(auth_token),
+            cookie: auth_token_details.auth_token_as_cookie_raw(auth_token, "Lax"),
         }
     }
 }

--- a/krill-server/assets/translations/support-mail-verification-page/en-US.bcp47
+++ b/krill-server/assets/translations/support-mail-verification-page/en-US.bcp47
@@ -4,3 +4,5 @@ loading_verification_page = Loading Verification Page
 support_email_verify_subheader = A verification link has been sent to 
 resend_verification_code = Resend Verification Code
 seconds = seconds
+retry_in = Retry in
+krill_shield = Shield logo

--- a/krill-server/src/backend/server_utils.rs
+++ b/krill-server/src/backend/server_utils.rs
@@ -63,10 +63,6 @@ impl MediaTypeHttp {
             .0)
     }
 
-    pub fn take(self) -> Response {
-        self.0
-    }
-
     pub fn set_header(mut self, key: &'static str, value: HeaderValue) -> Self {
         self.0.headers_mut().insert(key, value);
 

--- a/krill-server/src/backend/verification.rs
+++ b/krill-server/src/backend/verification.rs
@@ -188,7 +188,9 @@ pub async fn verify_support_mail(token: String) -> ServerFnResult<Response> {
     redirect_success_header(&mut res)?;
     build_cookie(
         &mut res,
-        &auth_details.details.auth_token_as_cookie_raw(store_key),
+        &auth_details
+            .details
+            .auth_token_as_cookie_raw(store_key, "Lax"),
     )?;
 
     Ok(res)
@@ -697,7 +699,7 @@ fn redirect_error_header(res: &mut Response, error: &str) -> ServerFnResult<()> 
 
 #[cfg(feature = "server")]
 fn redirect_success_header(res: &mut Response) -> ServerFnResult<()> {
-    *res.status_mut() = StatusCode::SEE_OTHER;
+    *res.status_mut() = StatusCode::TEMPORARY_REDIRECT;
 
     let route = crate::RouteUtils::DASHBOARD
         .parse::<dioxus_fullstack::HeaderValue>()

--- a/krill-server/src/frontend/pages/configuration/verification.rs
+++ b/krill-server/src/frontend/pages/configuration/verification.rs
@@ -118,7 +118,7 @@ fn event_succeeded(text_content: &str) -> Element {
                 img { src: crate::CHECKMARK_URL, alt: "checkmark" }
             }
 
-            span { class: "hidden md:flex px-0.5  font-[subheadingfont]
+            span { class: "md:flex px-0.5  font-[subheadingfont]
                     font-bold font-black text-sm lg:text-lg  text-green-500",
                 {text_content}
             }
@@ -133,7 +133,7 @@ fn error_event(text_content: &str) -> Element {
                 img { src: crate::ERROR_ICON, alt: "error" }
             }
 
-            span { class: "hidden md:flex px-0.5  font-[subheadingfont]
+            span { class: "md:flex px-0.5  font-[subheadingfont]
                     font-bold font-black text-sm lg:text-lg  text-red-500",
                 {text_content}
             }

--- a/krill-server/src/frontend/pages/configuration/verify_support_mail.rs
+++ b/krill-server/src/frontend/pages/configuration/verify_support_mail.rs
@@ -132,9 +132,12 @@ pub fn VerifySupportMail() -> Element {
             } else {
                 div { class: "flex flex-col w-full items-center justify-center",
                     div { class: "flex max-w-[200px] lg:max-w-[300px]",
-                        img { src: krill_logo, alt: "Shield Logo" }
+                        img {
+                            src: krill_logo,
+                            alt: translations.read().translate("krill_shield"),
+                        }
                     }
-                    div { class: "text-4xl font-[headingfont] dark:text-[var(--primary-color)] font-black",
+                    div { class: "flex text-center text-4xl font-[headingfont] dark:text-[var(--primary-color)] font-black items-center justify-center",
                         {translations.read().translate("support_email_verify_header")}
                     }
 
@@ -142,14 +145,15 @@ pub fn VerifySupportMail() -> Element {
 
                 if error_watcher.read().is_empty() {
                     if let Some(details_inner) = details.read().as_ref() {
-                        div { class: "flex flex-col",
+                        div { class: "flex flex-col items-center justify-center",
                             {translations.read().translate("support_email_verify_subheader")}
                             " "
                             {details_inner.obsf_mail.as_str()}
 
                             if let Some(count) = countdown.read().as_ref() {
                                 div { class: "flex w-full items-center justify-center mt-1 font-[monospacefont] text-lg",
-                                    "Retry in"
+
+                                    {translations.read().translate("retry_in")}
 
                                     span { class: "flex items-center justify-center ml-2 dark:text-[var(--primary-color)]",
                                         {count.to_string()}


### PR DESCRIPTION
feat: Use SameSite=Lax in cookies for easier authentication while preventing CSRF.

feat: Make building cookies also accept a parameter to apply where SameSite=Strict is needed